### PR TITLE
Renamed package com -> io due to Maven Central Repository naming convention

### DIFF
--- a/src/main/scala/io/github/windymelt/qw/Syntax.scala
+++ b/src/main/scala/io/github/windymelt/qw/Syntax.scala
@@ -1,4 +1,4 @@
-package com.github.windymelt.qw
+package io.github.windymelt.qw
 
 object Syntax:
   extension (sc: StringContext)

--- a/test/src/scala/com/github/windymelt/qw/SyntaxSuite.scala
+++ b/test/src/scala/com/github/windymelt/qw/SyntaxSuite.scala
@@ -1,4 +1,4 @@
-package com.github.windymelt.qw
+package io.github.windymelt.qw
 
 // For more information on writing tests, see
 // https://scalameta.org/munit/docs/getting-started.html


### PR DESCRIPTION
Renamed: `com.github.windymelt` -> `io.github.windymelt`